### PR TITLE
Replace version position on the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 from setuptools import setup, find_packages
 
-import widely
-
 setup(
     name='widely',
-    version=str(widely.__version__),
+    version='0.9',
     description='Static Site as a Service using AWS S3',
     long_description=open('README.rst').read(),
     author='Kyle Marek-Spartz and Michael Burling',

--- a/widely/__init__.py
+++ b/widely/__init__.py
@@ -29,18 +29,9 @@ Options:
 """
 
 import sys
+import pkg_resources
 
 from docopt import docopt
-
-
-__version__ = 0.9
-
-version_string = ''.join([
-    'widely/',
-    str(__version__),
-    ' python/',
-    sys.version
-])
 
 from widely.commands.help import _help
 from widely.commands.push import push
@@ -59,10 +50,18 @@ from widely.commands.open import _open
 def main():
     """
     Dispatch based on arguments.
+
     """
+    version_string = ''.join([
+        'widely/',
+        str(pkg_resources.require('widely')[0].version),
+        ' python/',
+        sys.version
+    ])
+
     arguments = docopt(__doc__, version=version_string, help=False)
     if arguments['version']:
-        version()
+        version(version_string)
     elif arguments['--help'] or arguments['help']:
         _help(arguments)
     elif arguments['auth:login'] or arguments['login']:

--- a/widely/commands/version.py
+++ b/widely/commands/version.py
@@ -1,7 +1,4 @@
-from widely import version_string
-
-
-def version():
+def version(version_string):
     """
     Displays current versions of Widely and Python.
 


### PR DESCRIPTION
Widely 0.9 could not install through pip caused by the version string dependency.
I replaced it on the setup.py and read it from the root **init**.py.
